### PR TITLE
FIX: Reuse operatingsystemmajrelease

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,8 +20,8 @@ class lldp ($package_source = '') {
     case $::operatingsystem {
       /RedHat|CentOS/ : {
         case $::operatingsystemmajrelease {
-          '7'    : { $repourl = "${baseurl}/RHEL_${::lsbmajdistrelease}" }
-          default: { $repourl = "${baseurl}/RedHat_RHEL-${::lsbmajdistrelease}" }
+          '7'    : { $repourl = "${baseurl}/RHEL_${::operatingsystemmajrelease}" }
+          default: { $repourl = "${baseurl}/RedHat_RHEL-${::operatingsystemmajrelease}" }
         }
 
         yumrepo { 'lldp':


### PR DESCRIPTION
Case statement is already using this (Facter 1.7+) version of the
fact, reuse it to avoid LSB dependency on RHEL.
